### PR TITLE
chore: set deep-diff to fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "connect-history-api-fallback": "1.3.0",
     "cross-spawn": "4.0.0",
     "css-loader": "0.24.0",
-    "deep-diff": "^0.3.4",
+    "deep-diff": "0.3.4",
     "deep-freeze": "0.0.1",
     "detect-port": "1.0.0",
     "dotenv": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "connect-history-api-fallback": "1.3.0",
     "cross-spawn": "4.0.0",
     "css-loader": "0.24.0",
-    "deep-diff": "0.3.4",
+    "deep-diff": "0.3.5",
     "deep-freeze": "0.0.1",
     "detect-port": "1.0.0",
     "dotenv": "2.0.0",


### PR DESCRIPTION
When npm pulls down version 0.3.6 the tests begin to fail.
This is just a workaround until we have figured out why!